### PR TITLE
Fix naming and fields in request data sent from frontend

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -15,11 +15,11 @@ function App() {
 
   const connection = new RabbitMQConnection(addResult);
 
-  const onSubmit = ({ phrase, directory }, fileFormats, searchModes) => {
+  const onSubmit = ({ phrase, path }, fileFormats, searchModes) => {
     clearResults();
     connection.sendRequest(
       phrase,
-      directory.replace(/\\/g, "/"),
+      path.replace(/\\/g, "/"),
       [...fileFormats],
       [...searchModes]
     );

--- a/frontend/src/Components/form/form.js
+++ b/frontend/src/Components/form/form.js
@@ -25,19 +25,19 @@ const Form = ({ onSubmit }) => {
   } = useForm({
     defaultValues: {
       phrase: "",
-      directory: "",
+      path: "",
     },
   });
 
   const fileFormats = [
-    "pptx",
-    "docx",
-    "txt",
-    "jpeg",
-    "jpg",
-    "png",
-    "mp4",
-    "zip",
+    ".pptx",
+    ".docx",
+    ".txt",
+    ".jpeg",
+    ".jpg",
+    ".png",
+    ".mp4",
+    ".zip",
   ];
   const searchModes = ["synonyms", "typos", "forms"];
 
@@ -50,11 +50,11 @@ const Form = ({ onSubmit }) => {
     setSelectedSearchModes([]);
   };
 
-  const handleDirectorySelect = () => {
+  const handlePathSelect = () => {
     window.api.selectFolder().then((result) => {
       if (!!result) {
-        resetField("directory");
-        setValue("directory", result);
+        resetField("path");
+        setValue("path", result);
       }
     });
   };
@@ -88,13 +88,13 @@ const Form = ({ onSubmit }) => {
           </FormErrorMessage>
         </FormControl>
 
-        <FormControl isInvalid={errors.directory}>
-          <FormLabel htmlFor="directory">Directory</FormLabel>
+        <FormControl isInvalid={errors.path}>
+          <FormLabel htmlFor="path">Directory path</FormLabel>
           <InputGroup flex flexDirection="column">
             <Input
-              id="directory"
+              id="path"
               placeholder="Enter directory path"
-              {...register("directory", {
+              {...register("path", {
                 required: "Directory path is required",
               })}
               type="text"
@@ -102,10 +102,10 @@ const Form = ({ onSubmit }) => {
               {...inputStyles}
             />
             <FormErrorMessage>
-              {errors.directory && errors.directory.message}
+              {errors.path && errors.path.message}
             </FormErrorMessage>
             <InputRightElement width="4.5rem">
-              <Button size="sm" onClick={handleDirectorySelect}>
+              <Button size="sm" onClick={handlePathSelect}>
                 Select
               </Button>
             </InputRightElement>

--- a/frontend/src/webSockets/RabbitMQConnection.js
+++ b/frontend/src/webSockets/RabbitMQConnection.js
@@ -18,8 +18,8 @@ export class RabbitMQConnection {
     this.client.connect("guest", "guest", onConnect, onError);
   }
 
-  sendRequest(phrase, directory, fileTypes, searchModes) {
-    const message = createMessage(phrase, directory, fileTypes, searchModes);
+  sendRequest(phrase, path, fileTypes, searchModes) {
+    const message = createMessage(phrase, path, fileTypes, searchModes);
     this.client.send(
       "/exchange/words/words." + getQueueName(searchModes),
       {},
@@ -28,14 +28,15 @@ export class RabbitMQConnection {
   }
 }
 
-function createMessage(phrase, directory, fileTypes, searchModes) {
+function createMessage(phrase, path, fileTypes, searchModes) {
   return {
     phrase: phrase,
-    directory: directory,
+    path: path,
     filters: {
-      fileTypes: fileTypes,
-      searchModes: searchModes,
+      filterTypes: fileTypes,
+      filterModes: searchModes,
     },
+    words: [phrase],
   };
 }
 


### PR DESCRIPTION
Example data sent from frontend:
```
{
  "phrase": "somephrase",
  "path": "/somedir/somefile.pptx",
  "filters": {
    "filterTypes": [
      ".pptx",
      ".docx",
      ".txt",
      ".jpeg",
      ".jpg",
      ".png",
      ".mp4",
      ".zip"
    ],
    "filterModes": ["synonyms", "typos", "forms"]
  },
  "words": ["somephrase"]
}
```